### PR TITLE
Use transport_url

### DIFF
--- a/templates/mitaka/neutron.conf
+++ b/templates/mitaka/neutron.conf
@@ -25,6 +25,8 @@ notification_driver = neutron.openstack.common.notifier.rpc_notifier
 default_notification_level = INFO
 notification_topics = notifications
 
+transport_url = rabbit://{{ rabbitmq_user }}:{{ rabbitmq_password }}@{{ rabbitmq_host }}:5672/openstack
+
 {% include "section-rabbitmq-oslo" %}
 
 [QUOTAS]


### PR DESCRIPTION
The newer versions of oslo look for transport_url for the connection
parameters.